### PR TITLE
go-rcc: use exec.LookPath to find gofmt binary

### DIFF
--- a/go-uic/rcc-tph.go
+++ b/go-uic/rcc-tph.go
@@ -147,7 +147,9 @@ func saveCode() {
 	qtrt.ErrPrint(err, savefile)
 
 	// gofmt the code
-	cmd := exec.Command("/usr/bin/gofmt", []string{"-w", savefile}...)
+	gofmtPath, err := exec.LookPath("gofmt")
+	qtrt.ErrPrint(err)
+	cmd := exec.Command(gofmtPath, "-w", savefile)
 	err = cmd.Run()
 	qtrt.ErrPrint(err, cmd)
 }


### PR DESCRIPTION
Hi kitech, and thanks for this interesting project!

I'm just trying it out now, and found that go-rcc gave me an error when trying to format the generated code. The problem seems to be that in my environment `gofmt` is not installed in `/usr/bin` and `go-rcc` doesn't try all folders in `$PATH`.

I made a small change which lets `go-rcc` use the `exec.LookPath` function which finds `gofmt` any folder in `$PATH`.