### PR TITLE
Include libffi with pkg-config for qtrt

### DIFF
--- a/qtrt/qtrt.go
+++ b/qtrt/qtrt.go
@@ -2,6 +2,7 @@ package qtrt
 
 /*
 #cgo CFLAGS: -std=c11
+#cgo pkg-config: libffi
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This fixes `fatal error: ffi.h: No such file or directory` which is happening for me on ArchLinux.