### PR TITLE
Update dl dependency to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/emirpasic/gods v1.9.0
 	github.com/gonuts/dl v0.0.0-20160302100715-9a2e942d3477 // indirect
 	github.com/huandu/xstrings v1.0.0 // indirect
-	github.com/kitech/dl v0.0.0-20160302100715-9a2e942d3477
+	github.com/kitech/dl v0.0.0-20180303092342-fa7e1b9bab3d
 	github.com/kitech/goplusplus v0.0.0-20171220130708-3b7427a37be0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lytics/base62 v0.0.0-20180122174218-827c93e361de // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/huandu/xstrings v1.0.0 h1:pO2K/gKgKaat5LdpAhxhluX2GPQMaI3W5FUz/I/UnWk
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/kitech/dl v0.0.0-20160302100715-9a2e942d3477 h1:d9LQ8IKrFCZFdEPo+FFQhpNnJCZyjvCrSQDbDfTs0YE=
 github.com/kitech/dl v0.0.0-20160302100715-9a2e942d3477/go.mod h1:rs/ASGqdrczQbnYVcZ+x5fk+EHouoBevEXKRqGDm8VI=
+github.com/kitech/dl v0.0.0-20180303092342-fa7e1b9bab3d h1:ogRgaJZWXzOU1avErN5v5mmoklS4n3akVxcCdicVtKM=
+github.com/kitech/dl v0.0.0-20180303092342-fa7e1b9bab3d/go.mod h1:rs/ASGqdrczQbnYVcZ+x5fk+EHouoBevEXKRqGDm8VI=
 github.com/kitech/goplusplus v0.0.0-20171220130708-3b7427a37be0 h1:EU69So/2tjEcAWABWuR21TiF0uy1mzIC7FX8d2NlyxU=
 github.com/kitech/goplusplus v0.0.0-20171220130708-3b7427a37be0/go.mod h1:cfrzDxXb+5ibsp0Q4G5LDpNs2BC6k7C4MGtflz2cdsQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=


### PR DESCRIPTION
On windows it produces a compilation error, as the pinned old version of
github.com/kitech/dl contains dlfcn symbols that are not there anymore.
Just updating to the lattest version solves the issue.

Closes: #44